### PR TITLE
Changed audio session category for playback init

### DIFF
--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -192,10 +192,11 @@
 {
     BOOL bSession = YES;
 
-    //if (!self.avSession) {
+    if (!self.avSession) {
         NSError* error = nil;
 
-        self.avSession = [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker error:nil];
+        self.avSession = [AVAudioSession sharedInstance] 
+        [self.avSession setCategory: AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker error:nil];
      
         if (error) {
             // is not fatal if can't get AVAudioSession , just log the error
@@ -203,7 +204,7 @@
             self.avSession = nil;
             bSession = NO;
         }
-   // }
+    }
     return bSession;
 }
 
@@ -348,8 +349,8 @@
                     bPlayAudioWhenScreenIsLocked = [playAudioWhenScreenIsLocked boolValue];
                 }
 
-                NSString* sessionCategory = bPlayAudioWhenScreenIsLocked ? AVAudioSessionCategoryPlayback : AVAudioSessionCategorySoloAmbient;
-                [self.avSession setCategory:sessionCategory error:&err];
+                NSString* sessionCategory = AVAudioSessionCategoryPlayAndRecord;
+                [self.avSession setCategory:sessionCategory withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker error:&err];
                 if (![self.avSession setActive:YES error:&err]) {
                     // other audio with higher priority that does not allow mixing could cause this to fail
                     NSLog(@"Unable to play audio: %@", [err localizedFailureReason]);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

